### PR TITLE
docs: 릴리즈 노트 업데이트

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           ./gradlew generateReleaseNote
           RELEASE_BODY=$(sed -n '2,$p' appRelease/release_note.txt | less)
+          RELEASE_BODY="${RELEASE_BODY//'%'/'%'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\n'/'\n'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\r'/'\r'}"
           echo "val=${RELEASE_BODY}" >> "$GITHUB_OUTPUT"
       - name: SetUp Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## 수정내용
- master 머지될때 Firebase AppTester 배포 및 릴리즈 생성 되도록 변경
- 기존에 create-release 유지보수 안되는 GitAction 변경 (ncipollo/release-action 변경)
- 릴리즈 생성시 Tag명은 날짜로 표시하도록 처리 ?

## 추가 내용
