### PR TITLE
Fix/git action

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,9 +2,9 @@ name: Android Build
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [develop, master]
   # pull_request:
-    # branches: [ develop ]
+  # branches: [ develop ]
 
 jobs:
   apk:
@@ -21,36 +21,20 @@ jobs:
       - name: set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: "17"
+          distribution: "adopt"
 
       # Android SDK 설정
       # - name: SetUp Android SDK
       #  uses: android-actions/setup-android@v2
 
-      # Dependency 에 버전 및 릴리즈 메시지 가져오기 working-directory -> 리포지토리 특성상 android 에서 빌드해야 되서 추가함
-      - name: Release Version
-        id: release
-        run: |
-          echo ::set-output name=code::$(grep versionCode buildSrc/src/main/java/Dependency.kt | awk '{print $5}')
-          echo ::set-output name=name::$(grep versionName buildSrc/src/main/java/Dependency.kt | awk '{print $5}')
-
-      # Tag 명 "" 제거해서 가져오기
-      - name: Get Version Name
-        id: version_name
-        run: echo ::set-output name=val::${{steps.release.outputs.name}}
-
-      - name: Get Version Code
-        id: version_code
-        run: echo ::set-output name=val::${{steps.release.outputs.code}}
+      # build.gradle.kts의 getAppVersion 태스크를 사용하여 버전 정보 가져오기
+      - name: Get App Version
+        id: version
+        uses: ./.github/actions/get-version
 
       - name: Print version
-        run: echo "Version ${{steps.version_code.outputs.val}}_${{steps.version_name.outputs.val}}"
-
-      # gradlew 권한 획득
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        # working-directory: ${{ env.working-directory }}
+        run: echo "Version ${{steps.version.outputs.version_code}}_${{steps.version.outputs.version_name}}"
 
       # Android Build Debug: assembleDebug Release: assembleRelease
       - name: Android Build
@@ -62,5 +46,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Generate Debug Apk
-          path: app/build/outputs/apk/debug/til_${{steps.version_code.outputs.val}}_${{steps.version_name.outputs.val}}-debug.apk
-
+          path: app/build/outputs/apk/debug/til_${{steps.version.outputs.version_code}}_${{steps.version.outputs.version_name}}-debug.apk

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   apk:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     # android 디렉토리 없앰으로 인한 주석 처리
     # env:
     #  working-directory: ./android

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -3,11 +3,16 @@ name: Android Build
 on:
   push:
     branches: [develop, master]
+  workflow_dispatch:  # 수동 실행을 위한 트리거
   # pull_request:
   # branches: [ develop ]
 
 jobs:
+  get_version:
+    uses: ./.github/workflows/android-version-info.yml
+
   apk:
+    needs: get_version
     runs-on: macos-latest
     # android 디렉토리 없앰으로 인한 주석 처리
     # env:
@@ -28,22 +33,20 @@ jobs:
       # - name: SetUp Android SDK
       #  uses: android-actions/setup-android@v2
 
-      # build.gradle.kts의 getAppVersion 태스크를 사용하여 버전 정보 가져오기
-      - name: Get App Version
-        id: version
-        uses: ./.github/actions/get-version
-
-      - name: Print version
-        run: echo "Version ${{steps.version.outputs.version_code}}_${{steps.version.outputs.version_name}}"
-
       # Android Build Debug: assembleDebug Release: assembleRelease
       - name: Android Build
         run: ./gradlew clean assembleDebug
         # working-directory: ${{ env.working-directory }}
 
-      # Debg Upload Apk
+      - name: Print Version Info
+        run: |
+          echo "Version Name: ${{ needs.get_version.outputs.version_name }}"
+          echo "Version Code: ${{ needs.get_version.outputs.version_code }}"
+          echo "Full Version: ${{ needs.get_version.outputs.version_name }} (${{ needs.get_version.outputs.version_code }})"
+
+      # Debug Upload Apk
       - name: Debug Apk
         uses: actions/upload-artifact@v2
         with:
           name: Generate Debug Apk
-          path: app/build/outputs/apk/debug/til_${{steps.version.outputs.version_code}}_${{steps.version.outputs.version_name}}-debug.apk
+          path: app/build/outputs/apk/debug/til_${{needs.get_version.outputs.version_code}}_${{needs.get_version.outputs.version_name}}-debug.apk

--- a/.github/workflows/android-version-info.yml
+++ b/.github/workflows/android-version-info.yml
@@ -1,28 +1,40 @@
-name: 'Get Android Version Info'
-description: 'Gets the versionName and versionCode from the app module using Gradle task'
+name: Get Android Version Info
 
-outputs:
-  version_name:
-    description: 'The version name of the app'
-    value: ${{ steps.get_version.outputs.name }}
-  version_code:
-    description: 'The version code of the app'
-    value: ${{ steps.get_version.outputs.code }}
+on:
+  workflow_call:
+    outputs:
+      version_name:
+        description: 'The version name of the app'
+        value: ${{ jobs.get_version.outputs.version_name }}
+      version_code:
+        description: 'The version code of the app'
+        value: ${{ jobs.get_version.outputs.version_code }}
 
-runs:
-  using: 'composite'
-  steps:
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-      shell: bash
-      
-    - name: Get Version from Gradle
-      id: get_version
-      run: |
-        VERSION_OUTPUT=$(./gradlew getAppVersion -PtargetModule=app --quiet)
-        VERSION_NAME=$(echo "$VERSION_OUTPUT" | awk '{print $1}')
-        VERSION_CODE=$(echo "$VERSION_OUTPUT" | sed 's/.*(\([0-9]*\)).*/\1/')
-        echo "name=$VERSION_NAME" >> $GITHUB_OUTPUT
-        echo "code=$VERSION_CODE" >> $GITHUB_OUTPUT
-      shell: bash
+jobs:
+  get_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version_name: ${{ steps.get_version.outputs.name }}
+      version_code: ${{ steps.get_version.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "adopt"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Get Version from Gradle
+        id: get_version
+        run: |
+          VERSION_OUTPUT=$(./gradlew getAppVersion -PtargetModule=app --quiet)
+          VERSION_NAME=$(echo "$VERSION_OUTPUT" | awk '{print $1}')
+          VERSION_CODE=$(echo "$VERSION_OUTPUT" | sed 's/.*(\([0-9]*\)).*/\1/')
+          echo "name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "code=$VERSION_CODE" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/android-version-info.yml
+++ b/.github/workflows/android-version-info.yml
@@ -1,0 +1,28 @@
+name: 'Get Android Version Info'
+description: 'Gets the versionName and versionCode from the app module using Gradle task'
+
+outputs:
+  version_name:
+    description: 'The version name of the app'
+    value: ${{ steps.get_version.outputs.name }}
+  version_code:
+    description: 'The version code of the app'
+    value: ${{ steps.get_version.outputs.code }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      shell: bash
+      
+    - name: Get Version from Gradle
+      id: get_version
+      run: |
+        VERSION_OUTPUT=$(./gradlew getAppVersion -PtargetModule=app --quiet)
+        VERSION_NAME=$(echo "$VERSION_OUTPUT" | awk '{print $1}')
+        VERSION_CODE=$(echo "$VERSION_OUTPUT" | sed 's/.*(\([0-9]*\)).*/\1/')
+        echo "name=$VERSION_NAME" >> $GITHUB_OUTPUT
+        echo "code=$VERSION_CODE" >> $GITHUB_OUTPUT
+      shell: bash
+

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -93,7 +93,7 @@ jobs:
             ${{ needs.deploy_firebase.outputs.releaseNoteHtml }}
 
   slack_notify:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: deploy_firebase
     steps:
       - uses: 8398a7/action-slack@v3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,23 @@ val properties = Properties().apply {
     load(FileInputStream(File(rootProject.rootDir, "local.properties")))
 }
 
+/**
+ * 버전명을 버전 코드로 변환
+ * 형식: Major.Minor.Patch (예: 1.1.10)
+ * 변환: Major * 1000000 + Minor * 1000 + Patch (예: 1.1.10 -> 1001010)
+ */
+fun String.toVersionCode(): Int {
+    val parts = this.split(".")
+    require(parts.size == 3) { "Version name must be in format Major.Minor.Patch (e.g., 1.1.10)" }
+    val major = parts[0].toInt()
+    val minor = parts[1].toInt()
+    val patch = parts[2].toInt()
+    require(major in 0 until 1000) { "Major version must be between 0 and 999" }
+    require(minor in 0 until 1000) { "Minor version must be between 0 and 999" }
+    require(patch in 0 until 1000) { "Patch version must be between 0 and 999" }
+    return major * 1000000 + minor * 1000 + patch
+}
+
 android {
     namespace = "com.hmju.til"
     compileSdk = 35
@@ -23,9 +40,9 @@ android {
         minSdk = 28
         targetSdk = 35
         applicationId = "com.hmju.til"
-        versionCode = 1
+        versionCode = libs.versions.appVersion.get().toVersionCode()
         versionName = libs.versions.appVersion.get()
-        setProperty("archivesBaseName", "til_${versionCode}_${versionName}")
+        setProperty("archivesBaseName", "til_${versionName}_${versionCode}")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/hmju/til/SchemeActivity.kt
+++ b/app/src/main/java/com/hmju/til/SchemeActivity.kt
@@ -43,7 +43,7 @@ class SchemeActivity : AppCompatActivity() {
 
     private fun handleDeeplink(uri: Uri) {
 	// 앱을 새로 실행해야함
-	Timber.d("Deeplink ${uri} ${isTaskRoot}")
+	Timber.d("Deeplink $uri ${isTaskRoot}")
 	if (isTaskRoot) {
 	    Intent(this, MainActivity::class.java).apply {
 		flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.io.BufferedReader
+import java.io.InputStreamReader
 
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -67,12 +69,24 @@ tasks.register("getAppVersion") {
 }
 
 fun getCommand(command: String): String {
-    val os = ByteArrayOutputStream()
-    exec {
-        commandLine = command.split(" ")
-        standardOutput = os
+    val process = ProcessBuilder("sh", "-c", command)
+        .directory(rootProject.rootDir)
+        .redirectErrorStream(true)
+        .start()
+    
+    val output = StringBuilder()
+    BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
+        reader.forEachLine { line ->
+            output.appendLine(line)
+        }
     }
-    return String(os.toByteArray())
+    
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+        throw RuntimeException("Command '$command' failed with exit code $exitCode")
+    }
+    
+    return output.toString().trim()
 }
 
 /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,20 +40,29 @@ tasks.register("generateReleaseNote") {
 
 // ./gradlew getAppVersion -PtargetModule=app
 tasks.register("getAppVersion") {
+    val targetService = project.properties["targetModule"] as? String ?: "app"
+    val moduleMap = mapOf(
+        "app" to "app"
+    )
+    val targetModule = moduleMap[targetService]
+        ?: throw IllegalArgumentException("Invalid service name: $targetService")
+    val targetProject = project(":$targetModule")
+    
+    // Ensure the target project is evaluated before accessing Android extension
+    dependsOn(targetProject.tasks.named("preBuild"))
+    
     doLast {
-        val targetService = project.properties["targetModule"] as? String ?: "app"
-        val moduleMap = mapOf(
-            "app" to "app"
-        )
-        val targetModule = moduleMap[targetService]
-            ?: throw IllegalArgumentException("Invalid service name: $targetService")
-        val targetProject = project(":$targetModule")
         val android = targetProject.extensions.getByName(
             "android"
         ) as com.android.build.gradle.BaseExtension
         val versionName = android.defaultConfig.versionName
         val versionCode = android.defaultConfig.versionCode
-        println("$versionName (${versionCode})")
+        
+        if (versionName == null || versionCode == null) {
+            throw IllegalStateException("Version information is not available for project :$targetModule. Make sure the project is evaluated and Android extension is configured.")
+        }
+        
+        println("$versionName ($versionCode)")
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-appVersion = "0.1.0"
+appVersion = "1.10.1"
 ## Android gradle plugin
 agp = "8.11.1"
 coreKtx = "1.13.1"


### PR DESCRIPTION
## Summary (요약)
- 기존에 Kotlin DSL 에서 Version Catalog Migrate 이후 이에 맞게  Github Action 의 Script 수정합니다. 
- 중간반영 테스트용..

## Background (배경)
<!-- 왜 이 작업이 필요했는지, 어떤 문제를 해결하는지 -->

## Planning (계획)

## Changeed (변경 사항)
<!-- 해결하려는 문제 -->

## Test (테스트)
<!-- 테스트 한 결과들을 적습니다. -->

## Related Issues
Closes #


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable CI step for consistent versioning and updates Gradle/build scripts to derive version info from the Version Catalog.
> 
> - New `android-version-info.yml` workflow runs `./gradlew getAppVersion -PtargetModule=app` and exposes `version_name`/`version_code` outputs
> - `android-build.yml` now depends on `get_version`, supports `workflow_dispatch`, runs on macOS, prints version info, and uploads debug APK named `til_${version_code}_${version_name}-debug.apk`
> - Root `build.gradle.kts`: hardens `getAppVersion` (target module mapping, `preBuild` dependency, null checks) and rewrites `getCommand` using `ProcessBuilder`
> - `app/build.gradle.kts`: adds `toVersionCode()` and sets `versionCode` from `libs.versions.appVersion`; archive name changed to `til_${versionName}_${versionCode}`
> - Bumps `appVersion` to `1.10.1`; minor log interpolation cleanup; Slack notify job runner switched to macOS
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 574d2d8354a785f9a741b9b5434f1cea4da68fd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->