### PR TITLE
Refactor/navigator merge navigate

### DIFF
--- a/.claude/pr-text.md
+++ b/.claude/pr-text.md
@@ -3,81 +3,115 @@
 ### 🎯 리팩토링 목적
 - [x] 코드 가독성 향상
 - [ ] 성능 개선
-- [x] 코드 중복 제거
+- [ ] 코드 중복 제거
 - [x] 아키텍처 개선
 - [ ] 테스트 용이성 개선
 - [ ] 기타:
 
 ### 📝 주요 변경사항
 
-**1. JSend response format payload 필드 제거**
-- `JSendList`, `JSendListWithMeta`의 중첩 구조(`data.payload`) 제거 → `list`, `meta` 최상위 필드로 단순화
-- `JSendObj`, `JSendObjWithMeta`, `JSendFlatConverterFactory` 클래스 삭제
-- `AuthManagerImpl` 토큰 파싱 로직: `data.payload` 중간 파싱 7줄 → 직접 역직렬화 1줄로 축약
-- `BaseJSend.isValid` 기본값 `false` → `get() = isSuccess` 로 실제 상태 반영
+**1. Navigator 코루틴 제거 및 동기화 전환**
 
-**2. 데이터 모델 네이밍 규칙 통일**
-- **API 응답 모델**: `*Entity` → `*DTO` (core 3개 + feature 23개, 총 26개 파일)
-  - `AuthTokenEntity` → `AuthTokenDTO`, `MetaEntity` → `MetaDTO`, `EmptyEntity` → `EmptyDTO`
-  - `GoodsEntity` → `GoodsDTO` (8개 feature 모듈)
-  - `FileEntity` → `FileDTO`, `MemoEntity` → `MemoDTO`, `JSendTestEntity` → `JSendTestDTO`
-  - `JSendEntity` → `JSendDTO`, `JwtTokenTestEntity` → `JwtTokenTestDTO`, `LikeEntity` → `LikeDTO`
-  - `CustomMetaEntity` → `CustomMetaDTO` (4개 feature 모듈)
-- **DB 모델**: `core/local/models/GoodsEntity` (`@Entity`) 유지
-- **Domain 모델**: `GoodsModel` → `Goods`, `MemoModel` → `Memo` (접미사 제거, 8개 모듈)
+- `Navigator.navigate()`: 반환값 `RouterResult` 제거 → `Unit` 반환
+- `Router.execute()`: `suspend fun` → 일반 `fun` 전환
+- `NavigatorImpl`: `GlobalScope.launch` + `withContext(Dispatchers.Main)` 제거 → 단순 반복문으로 대체
+- 불필요한 코루틴 의존성(`GlobalScope`, `Dispatchers`, `withContext`) 전부 삭제
 
-**3. Compose Status Bar Inset 처리 통일**
-- 전체 Compose Activity에 `enableEdgeToEdge()` + `windowInsetsPadding(WindowInsets.statusBars)` 적용
-  - `ComposeNavigationActivity`, `GeneralComposeActivity`, `MemoComposeUiActivity`, `ComposePermissionsResultActivity`, `PermissionScreen`
-- `RoomObserverActivity`: `ViewCompat.setOnApplyWindowInsetsListener` View 방식 제거 → Compose `windowInsetsPadding` 방식으로 교체
+**2. Navigator ActivityResult 지원 확장**
+
+- `Navigator.navigateForResult(context, uri, ActivityResultLauncher<Intent>)` 추가
+- `Router.isActivityResult(): Boolean` 플래그 추가 (기본값 `false`)
+- `Router.executeForResult(context, path, params, launcher)` open fun 추가
+- `NavigatorImpl.navigate()`: `isActivityResult() = true` 라우터 skip
+- `NavigatorImpl.navigateForResult()`: `isActivityResult() = true` 라우터만 처리
+
+**3. WebBridge 기반 클래스 추가 (core-navigator)**
+
+- `WebAction`: JavascriptInterface action key 열거형
+- `WebActionResult`: `Callback(dataMap)` / `Skip` sealed interface
+- `WebActionRouter`: `execute(WorkerThread)` + `completeCallback(MainThread)` 추상 클래스
+
+**4. activity_result 모듈 신규 추가**
+
+- `ActivityResultLauncher` 기반 화면 전환 예제 (`result_callback/` 패키지)
+- WebBridge 예제: 웹→앱 JavascriptInterface 통신 (`webbridge/` 패키지)
+  - `WebBridgeActionCommand`: `Channel<Pair<Router, Callback>>`(WorkerThread→MainThread) + `PublishSubject<ActivityResult>`(RxJava EventBus)
+  - `EditTextWebActionRouter`: WorkerThread `blockingFirst()` 블로킹 + 5초 timeout
+  - `AlertWebActionRouter`: 네이티브 AlertDialog → `evaluateJavascript` 콜백
 
 ### 📈 개선 효과
 
-**네이밍 규칙 통일 (Before/After)**
-```
-Before                          After
-─────────────────────────────────────────────────
-GoodsEntity (@Serializable)  →  GoodsDTO         ← API 응답
-GoodsEntity (@Entity Room)   →  GoodsEntity      ← DB 모델 (유지)
-GoodsModel                   →  Goods            ← Domain 모델
-```
-- 클래스명만으로 레이어 역할 구분 가능, 혼동 여지 제거
-- 101개 파일, 총 -415/+478줄 변경
-
-**JSend 구조 단순화 (Before/After)**
-```json
-// Before
-{ "data": { "payload": [...] } }
-
-// After
-{ "list": [...] }
-```
-- 불필요한 중첩 래퍼 클래스(`JSendObj`, `JSendObjWithMeta`) 73줄 삭제
-- 토큰 파싱 로직 7줄 → 1줄
-
-**Status Bar Inset (Before/After)**
+**Before**
 ```kotlin
-// Before (RoomObserverActivity)
-ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { v, insets ->
-    val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-    v.setPadding(systemBars.left, systemBars.top, systemBars.right, 0)
-    insets
+// 코루틴 기반 — GlobalScope 남용, 불필요한 스레드 전환
+override fun navigate(context: Context, uri: Uri): RouterResult {
+    GlobalScope.launch(Dispatchers.IO) {
+        val result = withContext(Dispatchers.Main) { router.execute(...) }
+    }
 }
 
-// After (모든 Compose Activity 동일 방식)
-Surface(
-    modifier = Modifier
-        .fillMaxSize()
-        .windowInsetsPadding(WindowInsets.statusBars)
-)
+// suspend 함수 — 모든 Router 구현체에 코루틴 강제
+abstract suspend fun execute(context: Context, ...): RouterResult
 ```
+
+**After**
+```kotlin
+// 단순 동기 반복 — 스레드 컨텍스트 명확
+override fun navigate(context: Context, uri: Uri) {
+    for (router in processors) {
+        if (router.isActivityResult()) continue
+        val result = router.execute(context, path, uri.toQueryMap())
+        if (result is RouterResult.Success) return
+    }
+}
+
+// 일반 함수 — 구현체 단순화
+abstract fun execute(context: Context, ...): RouterResult
+```
+
+- `navigate()` / `navigateForResult()` 분리로 일반 화면 전환과 ActivityResult 화면 전환의 책임이 명확히 구분됨
+- `ActivityResultLauncher` 등록 책임을 호출부(Activity/Fragment)에 위임 → 라이프사이클 안전
 
 ### 🔄 마이그레이션 가이드
 
-- `JSendObj<T>` → API 반환 타입을 `T` 로 직접 변경
-- `JSendList<T>` JSON 키: `data.payload` → `list` (서버 스펙 동반 변경)
-- `JSendListWithMeta<T, M>` JSON 키: `data.payload` / `data.meta` → `list` / `meta` (서버 스펙 동반 변경)
-- `*Entity` (API 모델) import 경로: 클래스명 `*DTO` 로 변경 필요
-- `GoodsModel` / `MemoModel` → `Goods` / `Memo` 로 변경 필요
+**Router 구현체 수정 필요**
+```kotlin
+// Before
+override suspend fun execute(context: Context, path: String, params: Map<String, String>): RouterResult
+
+// After
+override fun execute(context: Context, path: String, params: Map<String, String>): RouterResult
+```
+
+**navigate() 반환값 제거**
+```kotlin
+// Before
+val result = navigator.navigate(context, uri)
+
+// After
+navigator.navigate(context, uri)  // Unit 반환
+```
+
+**ActivityResult 화면 전환 방법**
+```kotlin
+// Activity/Fragment onCreate에서 런처 등록
+val launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result -> ... }
+
+// 필요할 때 navigate
+navigator.navigateForResult(this, Route.XXX.getUri(), launcher)
+
+// Router 구현체에서 isActivityResult() override 필수
+override fun isActivityResult(): Boolean = true
+override fun executeForResult(context, path, params, launcher): RouterResult {
+    launcher.launch(Intent(context, TargetActivity::class.java))
+    return RouterResult.Success()
+}
+```
 
 ### 🐵 Etc.
+
+**WebBridge EditTextWebActionRouter 동시 호출 주의**
+
+`PublishSubject`는 멀티캐스트 특성상, 동시에 두 개의 `execute()`가 블로킹 대기 중일 때 하나의 `ActivityResult`가 두 스레드 모두를 unblock할 수 있습니다.
+
+현재 예제 수준에서는 Activity가 떠 있는 동안 중복 호출이 불가하므로 실질적 문제 없음. 방어가 필요하다면 `Executors.newSingleThreadExecutor()` 사용 권장.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(find *)",
       "Bash(xargs sed *)",
       "Bash(./gradlew assembleDebug)",
-      "Bash(git commit -m ' *)"
+      "Bash(git commit -m ' *)",
+      "Bash(./gradlew :core-navigator:compileDebugKotlin :features:activity_result:compileDebugKotlin)"
     ]
   }
 }

--- a/core-navigator/src/main/java/com/hmju/core_navigator/Navigator.kt
+++ b/core-navigator/src/main/java/com/hmju/core_navigator/Navigator.kt
@@ -11,6 +11,5 @@ import androidx.activity.result.ActivityResultLauncher
  * Created by juhongmin on 2025. 11. 2.
  */
 interface Navigator {
-    fun navigate(context: Context, uri: Uri)
-    fun navigateForResult(context: Context, uri: Uri, launcher: ActivityResultLauncher<Intent>)
+    fun navigate(context: Context, uri: Uri, launcher: ActivityResultLauncher<Intent>? = null)
 }

--- a/core-navigator/src/main/java/com/hmju/core_navigator/Router.kt
+++ b/core-navigator/src/main/java/com/hmju/core_navigator/Router.kt
@@ -16,10 +16,6 @@ import dagger.hilt.android.internal.managers.ViewComponentManager
 abstract class Router {
     abstract fun route(): Route
 
-    open fun isActivityResult(): Boolean {
-	return false
-    }
-
     open fun matches(path: String): Boolean {
 	return path.startsWith(route().path)
     }

--- a/core-navigator/src/main/java/com/hmju/core_navigator/impl/NavigatorImpl.kt
+++ b/core-navigator/src/main/java/com/hmju/core_navigator/impl/NavigatorImpl.kt
@@ -19,55 +19,34 @@ internal class NavigatorImpl @Inject constructor(
     private val processors: Set<@JvmSuppressWildcards Router>
 ) : Navigator {
 
-    override fun navigate(context: Context, uri: Uri) {
-        val path = uri.path ?: return
-        Timber.d("Navigation $uri")
-        for (router in processors) {
-            Timber.d("Router ${router.isActivityResult()} ${router}")
-            if (router.isActivityResult()) continue
-            try {
-                if (router.matches(path)) {
-                    val result = router.execute(context, path, uri.toQueryMap())
-                    Timber.d("Result!!!! ${result}")
-                    if (result is RouterResult.Success) return
-                    Timber.d("Router Fail Result $result")
-                }
-            } catch (ex: Exception) {
-                Timber.e("Error $ex")
-                return
-            }
-        }
-    }
-
-    override fun navigateForResult(
-        context: Context,
-        uri: Uri,
-        launcher: ActivityResultLauncher<Intent>
-    ) {
-        val path = uri.path ?: return
-        Timber.d("NavigationForResult $uri")
-        for (router in processors) {
-            if (!router.isActivityResult()) continue
-            try {
-                if (router.matches(path)) {
-                    val result = router.executeForResult(context, path, uri.toQueryMap(), launcher)
-                    if (result is RouterResult.Success) return
-                    Timber.d("Router Fail Result $result")
-                }
-            } catch (ex: Exception) {
-                Timber.e("Error $ex")
-                return
-            }
-        }
+    override fun navigate(context: Context, uri: Uri, launcher: ActivityResultLauncher<Intent>?) {
+	val path = uri.path ?: return
+	Timber.d("Navigation $uri")
+	for (router in processors) {
+	    try {
+		if (router.matches(path)) {
+		    val result = if (launcher != null) {
+			router.executeForResult(context, path, uri.toQueryMap(), launcher)
+		    } else {
+			router.execute(context, path, uri.toQueryMap())
+		    }
+		    if (result is RouterResult.Success) return
+		    Timber.d("Router Fail Result $result")
+		}
+	    } catch (ex: Exception) {
+		Timber.e("Error $ex")
+		return
+	    }
+	}
     }
 
     private fun Uri.toQueryMap(): Map<String, String> {
-        return try {
-            queryParameterNames
-                .filterNot { it.isNullOrBlank() }
-                .associateWith { key -> getQueryParameter(key).orEmpty() }
-        } catch (_: Exception) {
-            emptyMap()
-        }
+	return try {
+	    queryParameterNames
+		.filterNot { it.isNullOrBlank() }
+		.associateWith { key -> getQueryParameter(key).orEmpty() }
+	} catch (_: Exception) {
+	    emptyMap()
+	}
     }
 }

--- a/features/activity_result/src/main/java/com/features/activity_result/RootActivity.kt
+++ b/features/activity_result/src/main/java/com/features/activity_result/RootActivity.kt
@@ -38,7 +38,7 @@ internal class RootActivity : BaseActivity<AActivityResultRootBinding, ActivityR
 	super.onCreate(savedInstanceState)
 	binding.toolbar.setNavigationOnClickListener { finish() }
 	binding.btnActivityResult.setOnClickListener {
-	    navigator.navigateForResult(
+	    navigator.navigate(
 		this,
 		Route.ACTIVITY_RESULT_CALLBACK.getUri(),
 		activityResultCallback

--- a/features/activity_result/src/main/java/com/features/activity_result/result_callback/ActivityResultCallbackRouter.kt
+++ b/features/activity_result/src/main/java/com/features/activity_result/result_callback/ActivityResultCallbackRouter.kt
@@ -29,10 +29,6 @@ internal class ActivityResultCallbackRouter @Inject constructor() : Router() {
 	fun bind(impl: ActivityResultCallbackRouter): Router
     }
 
-    override fun isActivityResult(): Boolean {
-	return true
-    }
-
     override fun route(): Route {
 	return Route.ACTIVITY_RESULT_CALLBACK
     }


### PR DESCRIPTION
## 🔨 Refactor

### 🎯 리팩토링 목적
- [x] 코드 가독성 향상
- [ ] 성능 개선
- [x] 코드 중복 제거
- [x] 아키텍처 개선
- [ ] 테스트 용이성 개선
- [ ] 기타:

### 📝 주요 변경사항

**1. `navigateForResult`를 `navigate`의 optional launcher 파라미터로 통합**

- `Navigator.navigate(context, uri, launcher: ActivityResultLauncher<Intent>? = null)` — `navigateForResult` 별도 함수 제거, `launcher` 옵셔널 파라미터로 흡수
- `Router.isActivityResult(): Boolean` 플래그 제거 — `NavigatorImpl`이 `launcher` null 여부로 `execute()` / `executeForResult()`를 직접 분기
- `NavigatorImpl.navigate()`: 라우터를 skip하던 분기 로직 제거, 단일 반복문에서 처리
- `ActivityResultCallbackRouter`의 `isActivityResult() = true` 오버라이드 제거
- `RootActivity`: `navigateForResult(...)` 호출부를 `navigate(..., launcher = ...)`로 변경

**2. TIL SDK 버전 업데이트**

### 📈 개선 효과

**Before**
```kotlin
interface Navigator {
    fun navigate(context: Context, uri: Uri)
    fun navigateForResult(context: Context, uri: Uri, launcher: ActivityResultLauncher<Intent>)
}

// Router
open fun isActivityResult(): Boolean = false

// NavigatorImpl - 진입점 2개, 플래그로 라우터 필터링
override fun navigate(context: Context, uri: Uri) {
    for (router in processors) {
        if (router.isActivityResult()) continue
        ...
    }
}

override fun navigateForResult(context: Context, uri: Uri, launcher: ActivityResultLauncher<Intent>) {
    for (router in processors) {
        if (!router.isActivityResult()) continue
        ...
    }
}
```

**After**
```kotlin
interface Navigator {
    fun navigate(context: Context, uri: Uri, launcher: ActivityResultLauncher<Intent>? = null)
}

// NavigatorImpl - 진입점 1개, launcher 유무로 분기
override fun navigate(context: Context, uri: Uri, launcher: ActivityResultLauncher<Intent>?) {
    for (router in processors) {
        if (router.matches(path)) {
            val result = if (launcher != null) {
                router.executeForResult(context, path, uri.toQueryMap(), launcher)
            } else {
                router.execute(context, path, uri.toQueryMap())
            }
            if (result is RouterResult.Success) return
        }
    }
}
```

- 호출부 진입점이 하나로 줄어 사용법이 단순해짐 (`navigate()`만 알면 됨, `launcher` 전달 여부로 동작 결정)
- `Router`에 `isActivityResult()` 플래그를 별도로 관리할 필요가 없어져 구현체 보일러플레이트 감소
- `NavigatorImpl` 내부의 두 반복문이 하나로 합쳐져 라우터 매칭 로직 중복 제거

### 🔄 마이그레이션 가이드

**ActivityResult 화면 전환 방법**
```kotlin
// Before
navigator.navigateForResult(this, Route.XXX.getUri(), launcher)

override fun isActivityResult(): Boolean = true
override fun executeForResult(context, path, params, launcher): RouterResult { ... }

// After
navigator.navigate(this, Route.XXX.getUri(), launcher = launcher)

// isActivityResult() 오버라이드 삭제, executeForResult()만 유지
override fun executeForResult(context, path, params, launcher): RouterResult { ... }
```

**일반 화면 전환은 변경 없음**
```kotlin
navigator.navigate(this, Route.XXX.getUri())
```